### PR TITLE
Passing flags to yarn filler

### DIFF
--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -20,7 +20,8 @@ services:
       - ./:/var/www/api
 
   filler:
-    command: ['sh', '-c', 'scripts/wq.sh && yarn filler ${FILLER_FLAGS}']
+    command:
+      ['sh', '-c', 'scripts/wq.sh && flags="${FILLER_FLAGS}" yarn filler']
     depends_on:
       - queue
     volumes:

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "mongo-indexes": "node dist/mongo_setup.js",
     "api": "tsc-watch --onSuccess \"node dist/api.js\"",
     "blockrange": "tsc-watch --onSuccess \"node dist/blockrange.js\"",
-    "filler": "tsc-watch --onSuccess \"node dist/filler.js\"",
+    "filler": "tsc-watch --onSuccess \"node dist/filler.js ${flags}\"",
     "processor": "tsc-watch --onSuccess \"node dist/processor.js\""
   },
   "husky": {


### PR DESCRIPTION
To properly run the `filler` script through `tsc-watch`, we must pass additional options, to do this we had to pass these options under the "flags" parameter