### PR TITLE
Redoc UI added for Local Development to Render API

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,3 +117,8 @@ This command is part of the CI chain and normally don't need to run locally.
 Requires a successful docker login to the registry first ([please read the official documentation](https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry)), then you can pull the images (instead of building locally).
 
 `docker compose pull`
+
+# API Access
+
+- In local development mode the API is accessible at https://localhost:8900
+- For extending / updating our API documentation, please look into the official [fastify-oas](https://github.com/SkeLLLa/fastify-oas) documentation.

--- a/README.md
+++ b/README.md
@@ -120,5 +120,5 @@ Requires a successful docker login to the registry first ([please read the offic
 
 # API Access
 
-- In local development mode the API is accessible at https://localhost:8900
+- In local development mode the API is accessible at http://localhost:8900
 - For extending / updating our API documentation, please look into the official [fastify-oas](https://github.com/SkeLLLa/fastify-oas) documentation.

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -48,5 +48,15 @@ services:
       timeout: 10s
       retries: 5
 
+  apidoc:
+    image: redocly/redoc
+    depends_on:
+      - api
+    environment:
+      - PAGE_TITLE="Alien Worlds API"
+      - SPEC_URL=http://localhost:8800/v1/alienworlds/docs/json
+    ports:
+      - '8900:80'
+
 volumes:
   database:


### PR DESCRIPTION
* Official [Redocly](https://hub.docker.com/r/redocly/redoc/) container added to Local Development
* Api definition (json) updates in real time in Local Development mode
* Redoc API UI is accessible at http://localhost:8900

<img width="956" alt="Screen Shot 2022-01-20 at 8 39 33 AM" src="https://user-images.githubusercontent.com/1231708/150383533-9e41af73-1e5b-4023-abcf-f81343f08759.png">

