### PR TITLE
improve api tests runner, add mongo seed

### DIFF
--- a/Dockerfile.api.tests
+++ b/Dockerfile.api.tests
@@ -1,4 +1,11 @@
-FROM node:17-alpine3.12
+FROM mongo AS mongo-seed
+
+COPY tests/api/fixtures/mines.seed.json /mines.seed.json
+## drop existing test db and reimport seed for fresh test
+CMD mongoimport --host db --db alienworlds_mainnet --collection mines --type json --file /mines.seed.json --jsonArray --drop
+
+
+FROM node:17-alpine3.12 AS api-tests-runner
 
 ENV NODE_ENV=api-tests
 

--- a/docker-compose-api-tests.yml
+++ b/docker-compose-api-tests.yml
@@ -1,22 +1,32 @@
-version: "3"
+version: '3'
 services:
-  api-tests:
+  api-tests-runner:
     tty: true
     build:
       context: .
+      target: api-tests-runner
       dockerfile: Dockerfile.api.tests
     ports:
-      - "8800:8800"
-    command: ["sh", "-c", "yarn test:api"]
+      - '8800:8800'
+    command: ['sh', '-c', 'yarn test:api']
     depends_on:
       - db
 
   db:
     image: mongo
     ports:
-      - "27017"
+      - '27017'
     volumes:
       - database:/data/db
+  mongo-seed:
+    build:
+      context: .
+      target: mongo-seed
+      dockerfile: Dockerfile.api.tests
+    links:
+      - db
+    depends_on:
+      - db
 
 volumes:
   database:

--- a/scripts/run-api-tests.sh
+++ b/scripts/run-api-tests.sh
@@ -1,4 +1,16 @@
 #!/bin/sh
 
 script="$(dirname $0)/../docker-compose-api-tests.yml"
-docker compose -f $script up --build --abort-on-container-exit --exit-code-from api-tests
+docker compose -p tests -f $script up --build -d
+
+TESTS_RUNNER_CONTAINER_ID=$(docker ps -aqf "name=^tests-api-tests-runner-1$")
+TEST_EXIT_CODE=`docker wait $TESTS_RUNNER_CONTAINER_ID`
+
+# Log tests results
+docker logs $TESTS_RUNNER_CONTAINER_ID
+
+# Clean
+docker-compose -p tests kill
+docker-compose -p tests rm -f
+
+exit $TEST_EXIT_CODE

--- a/tests/api/fixtures/mines.seed.json
+++ b/tests/api/fixtures/mines.seed.json
@@ -1,0 +1,56 @@
+[
+  {
+    "_id": {
+      "$oid": "61dee6039181c700422ef773"
+    },
+    "miner": "fakeminer1.wam",
+    "params": {
+      "invalid": 0,
+      "error": "",
+      "delay": 560,
+      "difficulty": 0,
+      "ease": 69,
+      "luck": 6,
+      "commission": 95
+    },
+    "bounty": 919,
+    "land_id": "1099512958747",
+    "planet_name": "neri.world",
+    "landowner": "fakeowner1.wam",
+    "bag_items": [1099561713548, 1099561713532, 1099561713528],
+    "offset": 1817,
+    "block_num": 161084966,
+    "block_timestamp": {
+      "$date": "2022-01-12T14:27:41Z"
+    },
+    "global_sequence": 34647697390,
+    "tx_id": "3d6d93bb26201b42007aa165d1e92dad880367972c93ede6b6f8672d330f65a7"
+  },
+  {
+    "_id": {
+      "$oid": "61dee6039181c700422ef774"
+    },
+    "miner": "fakeminer2.wam",
+    "params": {
+      "invalid": 0,
+      "error": "",
+      "delay": 1440,
+      "difficulty": 3,
+      "ease": 342,
+      "luck": 36,
+      "commission": 100
+    },
+    "bounty": 3040,
+    "land_id": "1099512959772",
+    "planet_name": "kavian.world",
+    "landowner": "fakeowner2",
+    "bag_items": [1099527305436, 1099530543733, 1099540916974],
+    "offset": 14,
+    "block_num": 161084966,
+    "block_timestamp": {
+      "$date": "2022-01-12T14:27:41Z"
+    },
+    "global_sequence": 34647697423,
+    "tx_id": "7a8d691a403e1d94e5a13ae3f53bef4b3b35b4a93bc11dabb61d3f607e6880e4"
+  }
+]


### PR DESCRIPTION
This PR is a copy of a previously created and approved [PR#10](https://github.com/Alien-Worlds/alienworlds-api/pull/10).
It contains:

- improved API runner script
- added mongo-seed to enable writing tests