### PR TITLE
Simplified API Testing (Foreground)

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,4 +1,4 @@
 #!/bin/sh
 . "$(dirname "$0")/_/husky.sh"
 
-yarn lint-staged && yarn test:unit
+yarn lint-staged

--- a/docker-compose-api-tests.yml
+++ b/docker-compose-api-tests.yml
@@ -1,23 +1,14 @@
-version: '3'
+version: '3.7'
 services:
   api-tests-runner:
-    tty: true
     build:
       context: .
       target: api-tests-runner
       dockerfile: Dockerfile.api.tests
-    ports:
-      - '8800:8800'
     command: ['sh', '-c', 'yarn test:api']
     depends_on:
       - db
 
-  db:
-    image: mongo
-    ports:
-      - '27017'
-    volumes:
-      - database:/data/db
   mongo-seed:
     build:
       context: .
@@ -27,6 +18,13 @@ services:
       - db
     depends_on:
       - db
+
+  db:
+    image: mongo
+    ports:
+      - '27017'
+    volumes:
+      - database:/data/db
 
 volumes:
   database:

--- a/scripts/run-api-tests.sh
+++ b/scripts/run-api-tests.sh
@@ -1,16 +1,6 @@
 #!/bin/sh
 
-script="$(dirname $0)/../docker-compose-api-tests.yml"
-docker compose -p tests -f $script up --build -d
-
-TESTS_RUNNER_CONTAINER_ID=$(docker ps -aqf "name=^tests-api-tests-runner-1$")
-TEST_EXIT_CODE=`docker wait $TESTS_RUNNER_CONTAINER_ID`
-
-# Log tests results
-docker logs $TESTS_RUNNER_CONTAINER_ID
-
-# Clean
-docker-compose -p tests kill
-docker-compose -p tests rm -f
-
-exit $TEST_EXIT_CODE
+TEST_COMPOSE="$(dirname "$0")/../docker-compose-api-tests.yml"
+docker compose -p tests -f "$TEST_COMPOSE" build
+docker compose -p tests -f "$TEST_COMPOSE" run api-tests-runner
+exit $?


### PR DESCRIPTION
* Simplified `run-api-tests.sh` by removing daemons and running test in the foreground
* Fixed docker compose version (3.7)
* removed unit tests from husky as it was hanging. It should be part of the CI, not necessarily part of the push hook (dockerized version should be available locally - in a follow up PR).