### PR TITLE
Cu-24nu2kb nfts unit tests

### DIFF
--- a/src/api-handlers/__tests__/fixtures/nfts.fixture.ts
+++ b/src/api-handlers/__tests__/fixtures/nfts.fixture.ts
@@ -1,0 +1,174 @@
+import {
+  NFT,
+  NFTDocument,
+  NFTResult,
+  NFTSearchQuery,
+  NFTsRequestQueryOptions,
+  NFTsResponse,
+  Rarity,
+} from '../../nfts';
+
+export const sampleNFTDocument: NFTDocument = {
+  _id: '61eee6039181c700422ef773',
+  miner: 'fakeminer1.wam',
+  land_id: '1099512961112',
+  params: {
+    invalid: 0,
+    error: '',
+    delay: 540,
+    difficulty: 3,
+    ease: 150,
+    luck: 25,
+    commission: 0,
+  },
+  rand1: 1.1764705882352942,
+  rand2: 1.9058518348973832,
+  rand3: 10.349019607843136,
+  template_id: 19558,
+  block_num: 124900087,
+  block_timestamp: { date: '2022-02-17T01:05:38.000Z' },
+  global_sequence: 8775201844,
+  template_data: {
+    cardid: 7,
+    name: 'Standard Capacitor',
+    img: 'QmaFe19mBfZWn2tvEN7Ea8xjdirnQQRisUGGBzBPb',
+    backimg: 'QmaUNXHee4vPCC3vpGTr77tJvBHjh1ndUm4J7o4tP',
+    rarity: 'Abundant',
+    shine: 'Stone',
+    type: 'Manipulator',
+    delay: 75,
+    difficulty: 1,
+    ease: 10,
+    luck: 5,
+    movecost: 20,
+  },
+};
+
+export const sampleNFT: NFT = {
+  id: '61eee6039181c700422ef773',
+  miner: 'fakeminer1.wam',
+  landId: '1099512961112',
+  params: {
+    invalid: 0,
+    error: '',
+    delay: 540,
+    difficulty: 3,
+    ease: 150,
+    luck: 25,
+    commission: 0,
+  },
+  rand1: 1.1764705882352942,
+  rand2: 1.9058518348973832,
+  rand3: 10.349019607843136,
+  templateId: 19558,
+  blockNumber: 124900087,
+  blockTimestamp: '2022-02-17T01:05:38.000Z',
+  globalSequence: 8775201844,
+  templateData: {
+    cardId: 7,
+    name: 'Standard Capacitor',
+    img: 'QmaFe19mBfZWn2tvEN7Ea8xjdirnQQRisUGGBzBPb',
+    backImg: 'QmaUNXHee4vPCC3vpGTr77tJvBHjh1ndUm4J7o4tP',
+    rarity: 'Abundant',
+    shine: 'Stone',
+    type: 'Manipulator',
+    delay: 75,
+    difficulty: 1,
+    ease: 10,
+    luck: 5,
+    moveCost: 20,
+  },
+};
+
+export const sampleNFTResult: NFTResult = {
+  _id: '61eee6039181c700422ef773',
+  miner: 'fakeminer1.wam',
+  land_id: '1099512961112',
+  params: {
+    invalid: 0,
+    error: '',
+    delay: 540,
+    difficulty: 3,
+    ease: 150,
+    luck: 25,
+    commission: 0,
+  },
+  rand1: 1.1764705882352942,
+  rand2: 1.9058518348973832,
+  rand3: 10.349019607843136,
+  template_id: 19558,
+  block_num: 124900087,
+  block_timestamp: '2022-02-17T01:05:38.000Z',
+  global_sequence: 8775201844,
+  template_data: {
+    cardid: 7,
+    name: 'Standard Capacitor',
+    img: 'QmaFe19mBfZWn2tvEN7Ea8xjdirnQQRisUGGBzBPb',
+    backimg: 'QmaUNXHee4vPCC3vpGTr77tJvBHjh1ndUm4J7o4tP',
+    rarity: 'Abundant',
+    shine: 'Stone',
+    type: 'Manipulator',
+    delay: 75,
+    difficulty: 1,
+    ease: 10,
+    luck: 5,
+    movecost: 20,
+  },
+};
+
+export const sampleNFTsResponse: NFTsResponse = {
+  results: [sampleNFTResult],
+  count: 1000,
+};
+
+export const block_timestamp_from = '2022-01-20T19:29:41.000+00:00';
+export const block_timestamp_to = '2022-03-21T19:29:41.000+00:00';
+export const block_timestamp_fromTimestamp = 1642706981000;
+export const block_timestamp_toTimestamp = 1647890981000;
+export const global_sequence_from = 37593403953;
+export const global_sequence_to = 37593403955;
+
+export const nftsRequestQueryOptions: NFTsRequestQueryOptions = {
+  miner: 'fakeminer1.wam',
+  land_id: '1099512961112',
+  rarity: 'Abundant',
+  from: block_timestamp_from,
+  to: block_timestamp_to,
+  global_sequence_from,
+  global_sequence_to,
+};
+
+export const nftsSearchQuery: NFTSearchQuery = {
+  miner: 'fakeminer1.wam',
+  'template_data.rarity': 'Abundant',
+  land_id: { $in: ['1099512961112'] },
+  block_timestamp: {
+    $gte: new Date(block_timestamp_fromTimestamp),
+    $lt: new Date(block_timestamp_toTimestamp),
+  },
+  global_sequence: { $gte: global_sequence_from, $lt: global_sequence_to },
+};
+
+export const wrongRarityNftsRequestQueryOptions: NFTsRequestQueryOptions = {
+  ...nftsRequestQueryOptions,
+  rarity: 'Fake',
+};
+
+export const noFromTimestampsNftsRequestQueryOptions: NFTsRequestQueryOptions =
+  {
+    miner: 'fakeminer1.wam',
+    land_id: '1099512961112',
+    rarity: 'Abundant',
+    to: block_timestamp_to,
+    global_sequence_to,
+  };
+
+export const noFromTimestampsNftsSearchQuery: NFTSearchQuery = {
+  miner: 'fakeminer1.wam',
+  'template_data.rarity': 'Abundant',
+  land_id: { $in: ['1099512961112'] },
+  block_timestamp: {
+    $lt: new Date(block_timestamp_toTimestamp),
+  },
+  global_sequence: { $lt: global_sequence_to },
+};

--- a/src/api-handlers/__tests__/mocks/nfts.fastify.mock.ts
+++ b/src/api-handlers/__tests__/mocks/nfts.fastify.mock.ts
@@ -1,0 +1,26 @@
+import { NFTDocument } from '../../nfts';
+
+export const getNFTsFastifyMock = (options: {
+  findResult?: NFTDocument[];
+  countResult?: number;
+}) => {
+  const { findResult, countResult } = options;
+  const nfts = findResult ? [...findResult] : [];
+
+  return {
+    mongo: {
+      db: {
+        collection: (name: string) => ({
+          find: (query: unknown, rest?: unknown) => ({
+            sort: (...args: unknown[]) => {
+              return {
+                limit: (value: number) => nfts.slice(0, value),
+              };
+            },
+            count: () => countResult || 0,
+          }),
+        }),
+      },
+    },
+  };
+};

--- a/src/api-handlers/__tests__/nfts.unit.test.ts
+++ b/src/api-handlers/__tests__/nfts.unit.test.ts
@@ -1,0 +1,127 @@
+import { getNFTsFastifyMock } from './mocks/nfts.fastify.mock';
+import {
+  nftsRequestQueryOptions,
+  nftsSearchQuery,
+  noFromTimestampsNftsRequestQueryOptions,
+  noFromTimestampsNftsSearchQuery,
+  sampleNFT,
+  sampleNFTDocument,
+  sampleNFTResult,
+  sampleNFTsResponse,
+  wrongRarityNftsRequestQueryOptions,
+} from './fixtures/nfts.fixture';
+import {
+  buildQuery,
+  getNFTs,
+  isValidRarity,
+  getSortingDirectionByString,
+  NFT,
+  NFTResult,
+  NFTsResponse,
+  countNFTs,
+} from '../nfts';
+
+describe('NFT unit tests', () => {
+  it('NFT.fromDto should return NFT entity based on data provided in given NFTDocument dto', async () => {
+    expect(NFT.fromDto(sampleNFTDocument)).toEqual(sampleNFT);
+  });
+});
+
+describe('NFTResult unit tests', () => {
+  it('NFTResult.fromEntity should return NFTResult model based on given NFT entity', async () => {
+    expect(NFTResult.fromEntity(sampleNFT)).toEqual(sampleNFTResult);
+  });
+});
+
+describe('NFTsResponse unit tests', () => {
+  it('NFTsResponse.create should return NFTsResponse model based on given NFT entities', async () => {
+    expect(NFTsResponse.create([sampleNFT], 1000)).toEqual(sampleNFTsResponse);
+  });
+});
+
+describe('"getSortingDirectionByString" unit tests', () => {
+  it('Should return 1 when given value is "asc" or any other variations', async () => {
+    expect(getSortingDirectionByString('asc')).toEqual(1);
+    expect(getSortingDirectionByString('ASC')).toEqual(1);
+    expect(getSortingDirectionByString('Asc')).toEqual(1);
+  });
+
+  it('Should return 1 when given value is "desc" or any other variations', async () => {
+    expect(getSortingDirectionByString('desc')).toEqual(-1);
+    expect(getSortingDirectionByString('DESC')).toEqual(-1);
+    expect(getSortingDirectionByString('Desc')).toEqual(-1);
+  });
+
+  it('It should throw an error when an invalid value is given', async () => {
+    const action = () => {
+      getSortingDirectionByString('%$#');
+    };
+    expect(action).toThrowError();
+  });
+});
+
+describe('"isValidRarity" unit tests', () => {
+  it('Should return true when given value is one of the valid rarity types', async () => {
+    expect(isValidRarity('Abundant')).toEqual(true);
+    expect(isValidRarity('Common')).toEqual(true);
+    expect(isValidRarity('Rare')).toEqual(true);
+    expect(isValidRarity('Epic')).toEqual(true);
+    expect(isValidRarity('Legendary')).toEqual(true);
+  });
+
+  it('Should return false when an invalid value is give', async () => {
+    expect(isValidRarity('Bieszczady')).toEqual(false);
+  });
+});
+
+describe('"getNFTs" unit tests', () => {
+  it('Should return collection of NFT entities', async () => {
+    const collection = await getNFTs(
+      getNFTsFastifyMock({ findResult: [sampleNFTDocument] }),
+      {}
+    );
+
+    expect(collection).toEqual([sampleNFT]);
+  });
+
+  it('It should throw an error when an given limit option is > 1000', async () => {
+    await getNFTs(getNFTsFastifyMock({ findResult: [] }), {
+      query: { limit: 1001 },
+    }).catch(error => {
+      expect(error).toBeInstanceOf(Error);
+    });
+  });
+});
+
+describe('"countNFTs" unit tests', () => {
+  it('Should return number of documents', async () => {
+    const count = await countNFTs(
+      getNFTsFastifyMock({ countResult: 1000 }),
+      {}
+    );
+    expect(count).toEqual(1000);
+  });
+});
+
+describe('"buildQuery" unit tests', () => {
+  it('Should return empty query when no options are given', async () => {
+    expect(buildQuery({})).toEqual({});
+  });
+
+  it('Should build a query based on given options', async () => {
+    expect(buildQuery(nftsRequestQueryOptions)).toEqual(nftsSearchQuery);
+  });
+
+  it('Should build a query based on given options without from and global_sequence_from', async () => {
+    expect(buildQuery(noFromTimestampsNftsRequestQueryOptions)).toEqual(
+      noFromTimestampsNftsSearchQuery
+    );
+  });
+
+  it('It should throw an error when an invalid rarity is given', async () => {
+    const action = () => {
+      buildQuery(wrongRarityNftsRequestQueryOptions);
+    };
+    expect(action).toThrowError();
+  });
+});

--- a/src/api-handlers/mineluck.ts
+++ b/src/api-handlers/mineluck.ts
@@ -40,9 +40,18 @@ export class MineLuck {
    * @returns {MineLuck} instance of MineLuck
    */
   public static fromDto(dto: MineLuckDocument): MineLuck {
-    const { _id, total_luck, total_mines, planets, tools, avg_luck, rarities } = dto;
+    const { _id, total_luck, total_mines, planets, tools, avg_luck, rarities } =
+      dto;
 
-    return new MineLuck(total_luck, total_mines, planets, tools, avg_luck, rarities, _id);
+    return new MineLuck(
+      total_luck,
+      total_mines,
+      planets,
+      tools,
+      avg_luck,
+      rarities,
+      _id
+    );
   }
 }
 
@@ -68,12 +77,21 @@ export class MineLuckResult {
    * @static
    * @public
    * @param {MineLuck} dto
-   * @returns {MineLuckResult} instance of MineLuck
+   * @returns {MineLuckResult} instance of MineLuckResult
    */
   public static fromEntity(entity: MineLuck): MineLuckResult {
-    const { totalLuck, totalMines, planets, tools, avgLuck, rarities, miner } = entity;
+    const { totalLuck, totalMines, planets, tools, avgLuck, rarities, miner } =
+      entity;
 
-    return new MineLuckResult(totalLuck, totalMines, planets, tools, avgLuck, rarities, miner);
+    return new MineLuckResult(
+      totalLuck,
+      totalMines,
+      planets,
+      tools,
+      avgLuck,
+      rarities,
+      miner
+    );
   }
 }
 
@@ -84,7 +102,10 @@ export class MineLuckResult {
  * @class
  */
 export class MineLuckResponse {
-  private constructor(public readonly results: MineLuckResult[], public readonly count: number) {}
+  private constructor(
+    public readonly results: MineLuckResult[],
+    public readonly count: number
+  ) {}
 
   /**
    * Creates instances of the class MineLuckResponse
@@ -184,7 +205,10 @@ export const createMineLuckPipeline = (from?: string, to?: string) => {
  * @param request request object
  * @returns {Promise<MineLuck[]>} List of the `MineLuck` objects
  */
-export const getMineLuckCollection = async (fastify, request): Promise<MineLuck[]> => {
+export const getMineLuckCollection = async (
+  fastify,
+  request
+): Promise<MineLuck[]> => {
   const { query: { from = null, to = null } = {} } = request;
   const db = fastify.mongo.db;
   const collection = db.collection('mines');

--- a/src/api-handlers/nfts.ts
+++ b/src/api-handlers/nfts.ts
@@ -1,104 +1,499 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
-/* eslint-disable prefer-const */
+/* eslint-disable @typescript-eslint/no-unused-vars */
 
 import { nftsSchema } from '../schemas';
 
-const getNFTs = async (fastify, request) => {
-  const limit = request.query.limit || 20;
-  const sort = request.query.sort || null;
-  const global_sequence_from = request.query.global_sequence_from || 0;
-  const global_sequence_to = request.query.global_sequence_to || 0;
-  const miner = request.query.miner || null;
-  const rarity = request.query.rarity || null;
-  const land_id = request.query.land_id || null;
-  const from = request.query.from || null;
-  const to = request.query.to || null;
+export enum Rarity {
+  Abundant = 'Abundant',
+  Common = 'Common',
+  Rare = 'Rare',
+  Epic = 'Epic',
+  Legendary = 'Legendary',
+  Mythical = 'Mythical',
+}
+
+/**
+ * Represents the data structure of the NFT mongoDB document
+ * @type
+ */
+export type NFTDocument = {
+  _id: string;
+  miner: string;
+  land_id: string;
+  params: {
+    invalid?: number;
+    error?: string;
+    delay?: number;
+    difficulty?: number;
+    ease?: number;
+    luck?: number;
+    commission?: number;
+  };
+  rand1: number;
+  rand2: number;
+  rand3: number;
+  template_id: number;
+  block_num: number;
+  block_timestamp: {
+    date: string;
+  };
+  global_sequence: number;
+  template_data: {
+    cardid?: number;
+    name?: string;
+    img?: string;
+    backimg?: string;
+    rarity?: string;
+    shine?: string;
+    description?: string;
+    attack?: number;
+    defense?: number;
+    class?: string;
+    movecost?: number;
+    race?: string;
+    type?: string;
+    element?: string;
+    delay?: number;
+    difficulty?: number;
+    ease?: number;
+    luck?: number;
+  };
+};
+
+/**
+ * Represents the available /nfts request query options
+ * @type
+ */
+export type NFTsRequestQueryOptions = {
+  limit?: number;
+  global_sequence_from?: number;
+  global_sequence_to?: number;
+  sort?: 'asc' | 'desc';
+  miner?: string;
+  rarity?: Rarity;
+  land_id?: string;
+  from?: string;
+  to?: string;
+};
+
+/**
+ * Represents nft search query options
+ * @type
+ */
+export type NFTSearchQuery = {
+  block_timestamp?: { $gte?: Date; $lt?: Date };
+  global_sequence?: { $gte?: number; $lt?: number };
+  miner?: string;
+  land_id?: { $in: string[] };
+  planet_name?: string;
+  rarity?: string;
+  sort?: string;
+};
+
+/**
+ * Represents the data structure of the NFT params
+ * @type
+ */
+export type NFTParams = {
+  invalid?: number;
+  error?: string;
+  delay?: number;
+  difficulty?: number;
+  ease?: number;
+  luck?: number;
+  commission?: number;
+};
+
+/**
+ * Represents the data structure of the NFT template data
+ * @type
+ */
+export type NFTTemplateData = {
+  cardId?: number;
+  name?: string;
+  img?: string;
+  backImg?: string;
+  rarity?: string;
+  shine?: string;
+  description?: string;
+  class?: string;
+  attack?: number;
+  defense?: number;
+  moveCost?: number;
+  race?: string;
+  type?: string;
+  element?: string;
+  delay?: number;
+  difficulty?: number;
+  ease?: number;
+  luck?: number;
+};
+
+/**
+ * Represents the data structure of the NFTResult params
+ * @type
+ */
+export type NFTResultParams = {
+  invalid?: number;
+  error?: string;
+  delay?: number;
+  difficulty?: number;
+  ease?: number;
+  luck?: number;
+  commission?: number;
+};
+
+/**
+ * Represents the data structure of the NFTResult template data
+ * @type
+ */
+export type NFTResultTemplateData = {
+  cardid?: number;
+  name?: string;
+  img?: string;
+  backimg?: string;
+  rarity?: string;
+  shine?: string;
+  description?: string;
+  class?: string;
+  attack?: number;
+  defense?: number;
+  movecost?: number;
+  race?: string;
+  type?: string;
+  element?: string;
+  delay?: number;
+  difficulty?: number;
+  ease?: number;
+  luck?: number;
+};
+
+/**
+ * Represents computed mine luck data.
+ *
+ * @class
+ */
+export class NFT {
+  private constructor(
+    public readonly id: string,
+    public readonly miner: string,
+    public readonly landId: string,
+    public readonly params: NFTParams,
+    public readonly rand1: number,
+    public readonly rand2: number,
+    public readonly rand3: number,
+    public readonly templateId: number,
+    public readonly blockNumber: number,
+    public readonly blockTimestamp: string,
+    public readonly globalSequence: number,
+    public readonly templateData: NFTTemplateData
+  ) {}
+
+  /**
+   * Creates instances of the class NFT based on given NFTDocument.
+   *
+   * @static
+   * @public
+   * @param {NFTDocument} dto
+   * @returns {NFT} instance of NFT
+   */
+  public static fromDto(dto: NFTDocument): NFT {
+    const {
+      _id,
+      miner,
+      land_id,
+      params,
+      rand1,
+      rand2,
+      rand3,
+      template_id,
+      block_num,
+      block_timestamp,
+      global_sequence,
+      template_data,
+    } = dto;
+    const nftParams: NFTParams = {};
+    const nftTemplateData: NFTTemplateData = {};
+    const paramsKeys = Object.keys(params || {});
+    const templateDataKeys = Object.keys(template_data || {});
+
+    for (const key of paramsKeys) {
+      nftParams[key] = params[key];
+    }
+
+    for (const key of templateDataKeys) {
+      nftTemplateData[key] = template_data[key];
+    }
+
+    return new NFT(
+      _id,
+      miner,
+      land_id,
+      nftParams,
+      rand1,
+      rand2,
+      rand3,
+      template_id,
+      block_num,
+      block_timestamp.date,
+      global_sequence,
+      nftTemplateData
+    );
+  }
+}
+
+/**
+ * Represents NFT (view) model.
+ *
+ * @class
+ */
+export class NFTResult {
+  private constructor(
+    public readonly _id: string,
+    public readonly miner: string,
+    public readonly land_id: string,
+    public readonly params: NFTResultParams,
+    public readonly rand1: number,
+    public readonly rand2: number,
+    public readonly rand3: number,
+    public readonly template_id: number,
+    public readonly block_num: number,
+    public readonly block_timestamp: string,
+    public readonly global_sequence: number,
+    public readonly template_data: NFTResultTemplateData
+  ) {}
+
+  /**
+   * Creates instances of the NFTResult based on given NFT entity.
+   *
+   * @static
+   * @public
+   * @param {NFT} entity
+   * @returns {NFTResult} instance of NFTResult
+   */
+  public static fromEntity(entity: NFT): NFTResult {
+    const {
+      id,
+      miner,
+      landId,
+      rand1,
+      rand2,
+      rand3,
+      templateId,
+      blockNumber,
+      blockTimestamp,
+      globalSequence,
+      params,
+      templateData,
+    } = entity;
+
+    const resultParams: NFTResultParams = {};
+    const resultTemplateData: NFTResultTemplateData = {};
+    const paramsKeys = Object.keys(params || {});
+    const templateDataKeys = Object.keys(templateData || {});
+
+    for (const key of paramsKeys) {
+      resultParams[key] = params[key];
+    }
+
+    for (const key of templateDataKeys) {
+      resultTemplateData[key] = templateData[key];
+    }
+
+    return new NFTResult(
+      id,
+      miner,
+      landId,
+      resultParams,
+      rand1,
+      rand2,
+      rand3,
+      templateId,
+      blockNumber,
+      blockTimestamp,
+      globalSequence,
+      resultTemplateData
+    );
+  }
+}
+
+/**
+ * Represents the response (DTO) of the /nfts route.
+ * A serialized object of this class is returned as result of calling /nfts route.
+ *
+ * @class
+ */
+export class NFTsResponse {
+  private constructor(
+    public readonly results: NFTResult[],
+    public readonly count: number
+  ) {}
+
+  /**
+   * Creates instances of the class NFTsResponse
+   *
+   * @static
+   * @public
+   * @param {NFT[]} nfts
+   * @param {number} count
+   * @returns {NFTsResponse} instance of `NFTsResponse`
+   */
+  public static create(nfts: NFT[], count: number): NFTsResponse {
+    return new NFTsResponse(
+      nfts.map(entity => NFTResult.fromEntity(entity)),
+      count
+    );
+  }
+}
+
+/**
+ * Returns the numeric sort direction based on the provided expression.
+ * Without an argument, the function returns -1, otherwise it returns
+ * the appropriate value. If an invalid argument is given, the function returns an error
+ *
+ * @param {string=} value
+ * @returns {number}
+ */
+export const getSortingDirectionByString = (value?: string): number => {
+  if (value) {
+    if (value.toLowerCase() === 'asc') return 1;
+    if (value.toLowerCase() === 'desc') return -1;
+    throw new Error('Sort must be either "asc" or "desc"');
+  }
+  return -1;
+};
+
+/**
+ * Checks if provided value matches any of the rarity types
+ * ['Abundant', 'Common', 'Rare', 'Epic', 'Legendary']
+ *
+ * @param {string} value
+ * @returns {boolean}
+ */
+export const isValidRarity = (value: string): value is Rarity =>
+  Object.keys(Rarity).includes(value);
+
+/**
+ * Builds a search query based on the options passed in the request
+ *
+ * @param {MinesRequestQueryOptions} options query options
+ * @returns {MinesSearchQuery}
+ */
+export const buildQuery = (
+  options: NFTsRequestQueryOptions
+): NFTSearchQuery => {
+  const {
+    from,
+    to,
+    global_sequence_from,
+    global_sequence_to,
+    miner,
+    land_id,
+    rarity,
+  } = options;
+  const query: NFTSearchQuery = {};
+
+  if (miner) {
+    query.miner = miner;
+  }
+  if (rarity) {
+    if (isValidRarity(rarity)) {
+      query['template_data.rarity'] = rarity;
+    } else {
+      throw new Error(`Rarity parameter must be ${Object.keys(Rarity)}`);
+    }
+  }
+  if (land_id) {
+    query.land_id = { $in: land_id.split(',') };
+  }
+  if (from) {
+    query.block_timestamp = { $gte: new Date(Date.parse(from)) };
+  }
+  if (to && query.block_timestamp) {
+    query.block_timestamp.$lt = new Date(Date.parse(to));
+  } else if (to && !query.block_timestamp) {
+    query.block_timestamp = {
+      $lt: new Date(Date.parse(to)),
+    };
+  }
+
+  if (global_sequence_from) {
+    query.global_sequence = { $gte: global_sequence_from };
+  }
+
+  if (global_sequence_to && query.global_sequence) {
+    query.global_sequence.$lt = global_sequence_to;
+  } else if (global_sequence_to && !query.global_sequence) {
+    query.global_sequence = { $lt: global_sequence_to };
+  }
+
+  return query;
+};
+
+/**
+ * Connects to the MongoDB database and retrieves NFT documents
+ * that meet the specified conditions.
+ *
+ * @async
+ * @param fastify Fastify instance
+ * @param request request object
+ * @returns {Promise<NFT[]>} List of the `NFT` objects
+ */
+export const getNFTs = async (fastify, request): Promise<NFT[]> => {
+  const queryOptions: NFTsRequestQueryOptions = request?.query || {};
+  const limit = queryOptions.limit || 20;
 
   if (limit > 1000) {
     throw new Error('Limit maximum is 1000');
   }
 
-  let res = null,
-    query: any = {};
-  // let has_query = false
   const db = fastify.mongo.db;
   const collection = db.collection('nfts');
+  const sort = getSortingDirectionByString(queryOptions.sort);
+  const query = buildQuery(queryOptions);
+  const nfts: NFT[] = [];
+  const cursor = collection
+    .find(query)
+    .sort({ global_sequence: sort })
+    .limit(limit);
 
-  if (miner) {
-    query.miner = miner;
-    // has_query = true
-  }
-  if (land_id) {
-    if (land_id.indexOf(',') !== -1) {
-      const land_ids = land_id.split(',');
-      query.land_id = { $in: land_ids };
-    } else {
-      query.land_id = land_id;
-    }
-    console.log(query);
-    // has_query = true
-  }
-  if (rarity) {
-    if (
-      !['Abundant', 'Common', 'Rare', 'Epic', 'Legendary', 'Mythical'].includes(
-        rarity
-      )
-    ) {
-      throw new Error(
-        'Rarity parameter must be Abundant, Common, Rare, Epic, Legendary or Mythical'
-      );
-    }
-    query['template_data.rarity'] = rarity;
-    // has_query = true
-  }
-  if (from) {
-    if (typeof query.block_timestamp === 'undefined') {
-      query.block_timestamp = {};
-    }
-    query.block_timestamp.$gte = new Date(Date.parse(from));
-    // has_query = true
-  }
-  if (to) {
-    if (typeof query.block_timestamp === 'undefined') {
-      query.block_timestamp = {};
-    }
-    query.block_timestamp.$lt = new Date(Date.parse(to));
-    // has_query = true
-  }
-  let _sort = -1;
-  if (sort === 'asc' || sort === 'desc') {
-    _sort = sort === 'asc' ? 1 : -1;
-  } else if (sort) {
-    throw new Error('Sort must be either "asc" or "desc"');
+  for await (const dto of cursor) {
+    nfts.push(NFT.fromDto(dto));
   }
 
-  // perform the query
-  if (global_sequence_from) {
-    if (typeof query.global_sequence === 'undefined') {
-      query.global_sequence = {};
-    }
-    query.global_sequence['$gte'] = global_sequence_from;
-  }
-  if (global_sequence_to) {
-    if (typeof query.global_sequence === 'undefined') {
-      query.global_sequence = {};
-    }
-    query.global_sequence['$lt'] = global_sequence_to;
-  }
-  res = collection.find(query).sort({ global_sequence: _sort }).limit(limit);
-
-  const results = [];
-  await res.forEach(r => {
-    results.push(r);
-  });
-  const count_query = query;
-  if (count_query.global_sequence) {
-    delete count_query.global_sequence;
-  }
-
-  return { results, count: await collection.find(count_query).count() };
+  return nfts;
 };
 
+/**
+ * Connects to the MongoDB database and calculates the number of documents
+ * that meet the specified conditions.
+ *
+ * @async
+ * @param fastify Fastify instance
+ * @param request request object
+ * @returns {number} number of NFT documents
+ */
+export const countNFTs = async (fastify, request): Promise<number> => {
+  const {
+    global_sequence_from,
+    global_sequence_to,
+    ...queryOptions
+  }: NFTsRequestQueryOptions = request?.query || {};
+
+  const db = fastify.mongo.db;
+  const collection = db.collection('nfts');
+  const query = buildQuery(queryOptions);
+
+  return collection.find(query).count();
+};
+
+/**
+ * GET "/nfts" route declaration method
+ *
+ * @default
+ * @param fastify Fastify instance
+ * @param opts route options
+ * @param next
+ */
 export default function (fastify, opts, next) {
   fastify.get(
     '/nfts',
@@ -106,8 +501,9 @@ export default function (fastify, opts, next) {
       schema: nftsSchema.GET,
     },
     async (request, reply) => {
-      const res = await getNFTs(fastify, request);
-      reply.send(res);
+      const nfts = await getNFTs(fastify, request);
+      const count = await countNFTs(fastify, request);
+      reply.send(NFTsResponse.create(nfts, count));
     }
   );
   next();

--- a/src/api-handlers/nfts.ts
+++ b/src/api-handlers/nfts.ts
@@ -69,7 +69,7 @@ export type NFTsRequestQueryOptions = {
   global_sequence_to?: number;
   sort?: 'asc' | 'desc';
   miner?: string;
-  rarity?: Rarity;
+  rarity?: string;
   land_id?: string;
   from?: string;
   to?: string;
@@ -84,9 +84,7 @@ export type NFTSearchQuery = {
   global_sequence?: { $gte?: number; $lt?: number };
   miner?: string;
   land_id?: { $in: string[] };
-  planet_name?: string;
-  rarity?: string;
-  sort?: string;
+  'template_data.rarity'?: string;
 };
 
 /**
@@ -214,14 +212,29 @@ export class NFT {
     const nftParams: NFTParams = {};
     const nftTemplateData: NFTTemplateData = {};
     const paramsKeys = Object.keys(params || {});
-    const templateDataKeys = Object.keys(template_data || {});
 
     for (const key of paramsKeys) {
       nftParams[key] = params[key];
     }
 
+    const { cardid, backimg, movecost, ...restTemplateData } =
+      template_data || {};
+    const templateDataKeys = Object.keys(restTemplateData || {});
+
     for (const key of templateDataKeys) {
       nftTemplateData[key] = template_data[key];
+    }
+
+    if (cardid) {
+      nftTemplateData.cardId = cardid;
+    }
+
+    if (backimg) {
+      nftTemplateData.backImg = backimg;
+    }
+
+    if (movecost) {
+      nftTemplateData.moveCost = movecost;
     }
 
     return new NFT(
@@ -289,14 +302,29 @@ export class NFTResult {
     const resultParams: NFTResultParams = {};
     const resultTemplateData: NFTResultTemplateData = {};
     const paramsKeys = Object.keys(params || {});
-    const templateDataKeys = Object.keys(templateData || {});
 
     for (const key of paramsKeys) {
       resultParams[key] = params[key];
     }
 
+    const { cardId, backImg, moveCost, ...restTemplateData } =
+      templateData || {};
+    const templateDataKeys = Object.keys(restTemplateData || {});
+
     for (const key of templateDataKeys) {
-      resultTemplateData[key] = templateData[key];
+      resultTemplateData[key] = restTemplateData[key];
+    }
+
+    if (cardId) {
+      resultTemplateData.cardid = cardId;
+    }
+
+    if (backImg) {
+      resultTemplateData.backimg = backImg;
+    }
+
+    if (moveCost) {
+      resultTemplateData.movecost = moveCost;
     }
 
     return new NFTResult(


### PR DESCRIPTION
PR includes:

- refactored code to make it testable
- unit tests for the nfts handler
- nfts mocks
- nfts fixtures


While writing tests for this handler, I noticed that the documents retrieved from the database may have different parameters not present in rest of the given collection. It means that we have different categories // types of documents and data that we fetch. This is not a problem, but it should be documented and "typed" in our code. Appropriate logic can be written in mappers and everything will be consistent but it would be nice to list various parameters from the sub documents like  `'params'` or `'template_data'`.


A large number of types / classes may be surprising, but there are three stages of working with data to be considered. You should type the data obtained from the database (this is done with the help of `type` like `FooDocument` etc.) the data used in the logic layer / domain ... of the code and the data we need to return in the response. The question may arise why we must have separate entities of the same data. Well, they are not always the same - sometimes we only have to return part of the data from the object. Thats the first thing and the other is that params names may not comply with the standards adopted by us. For example, `tx_id` is not readable and easy to use - not to mention the syntax itself. In the layer where we operate on this data, it must be readable and then converted to the response requirements.


More about this and solutions will be prepared in the document and the new code structure. At the moment, we are preparing the ground for changes and testing the code.