### PR TITLE
Refactor GHA workflows

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,73 @@
+name: Deploy Packages & Docs
+
+concurrency:
+  group: build-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  PROD_BRANCH: master
+
+on:
+  push:
+    branches: [${{ PROD_BRANCH }}]
+  pull_request:
+    branches: [${{ PROD_BRANCH }}]
+    types: [closed]
+  workflow_dispatch:
+
+jobs:
+  docker:
+    name: "Build Docker"
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      packages: read
+      pull-requests: read
+    env:
+      DOCKER_REGISTRY: ghcr.io/alien-worlds
+      FILLER_FLAGS:
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Building dependencies
+        run: docker compose run api yarn
+
+  ghp_deploy:
+    name: "Deploy to GHP"
+    depends_on: [docker]
+    if: github.event_name == 'pull_request' && github.event.pull_request.merged == true && github.base_ref == '${{ PROD_BRANCH }}'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      packages: read
+      pull-requests: read
+    steps:
+      - name: Generating OpenAPI definition
+        run: docker compose -f docker-compose.yml -f docker-compose.apigen.yml run apigen && docker compose down
+
+      - name: Generating Redoc
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./openapi
+          publish_branch: docs
+
+  packages_deploy:
+    name: "Deploy to GHP"
+    depends_on: [docker]
+    if: github.event_name == 'pull_request' && github.event.pull_request.merged == true && github.base_ref == '${{ PROD_BRANCH }}'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      packages: write
+      pull-requests: read
+    steps:
+      - name: Pushing Images to Registry
+        run: docker compose push

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,19 +1,19 @@
-name: lint
+name: Lint
 
 concurrency:
-  group: lint-${{ github.ref }}
+  group: build-${{ github.ref }}
   cancel-in-progress: true
 
 on:
   push:
-    branches: [master]
+    branches: [master, develop]
   pull_request:
-    branches: [master]
-
+    branches: [master, develop]
   workflow_dispatch:
 
 jobs:
-  lint:
+  docker:
+    name: "Build Docker"
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -35,18 +35,17 @@ jobs:
       - name: Building dependencies
         run: docker compose run api yarn
 
+  formatting:
+    name: "Code Formatting"
+    depends_on: [docker]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      packages: write
+      pull-requests: read
+    steps:
       - name: Running ESLint
         run: docker compose run api yarn lint-es
 
       - name: Running Prettier
         run: docker compose run api yarn lint-prettier
-
-      - name: Generating OpenAPI definition
-        run: docker compose -f docker-compose.yml -f docker-compose.apigen.yml run apigen && docker compose down
-
-      - name: Generating Redoc
-        uses: peaceiris/actions-gh-pages@v3
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./openapi
-          publish_branch: docs


### PR DESCRIPTION
**Lint**
- Removed Redoc build and deploy from lint
- Added multiple jobs to lint

**Deploy**
- Moved all `env` to global scope instead of job scope (DRY) 
- Created workflow that triggers on  PR merge (common case) and  production branch push (edge case, in the case of a force push for example)
- Deploys packages to GHP registry.
- Builds and deploys docs. 

**Notes**
- Created separate jobs for deploy, this is so that GH Pages deploy and Packages Deploy can occur in parallel. 