### PR TITLE
Detect logmine notifications to the new notify.world contract

### DIFF
--- a/config.js
+++ b/config.js
@@ -5,6 +5,7 @@ module.exports = {
     chain_id: '1064487b3cd1a897ce03ae5b6a865651747e2e152090f99c1d19d44e01aea5a4',
     endpoints: ["https://wax.eosdac.io"],
     mining_contract: 'm.federation',
+    notify_contract: 'notify.world',
     bsc_endpoint: '',
     eth_endpoint: '',
     bsc_token_contract: '',

--- a/src/handlers/tracehandler.ts
+++ b/src/handlers/tracehandler.ts
@@ -48,7 +48,8 @@ export class TraceHandler {
               case 'action_trace_v0':
                 if (
                   action[1].act.account === this.config.mining_contract ||
-                  action[1].act.account === this.config.atomicassets.contract
+                  action[1].act.account === this.config.atomicassets.contract ||
+                  action[1].act.account === this.config.notify_contract
                 ) {
                   this.stats.add('actions');
 

--- a/src/processor.ts
+++ b/src/processor.ts
@@ -257,6 +257,7 @@ class AlienAPIProcessor {
 
       switch (combined) {
         case 'm.federation::logmine':
+        case `${this.config.notify_contract}::logmine`:
           const [bounty_str] = data.bounty.split(' ');
           store_data.bounty = parseInt(bounty_str.replace('.', ''));
           store_data.block_num = Long.fromString(block_num.toString());


### PR DESCRIPTION
This change is backwards compatible so it will still pick up notifications going to m.federation just the same.