### PR TITLE
Add notify.world for abi fetching

### DIFF
--- a/src/fetch_abis.ts
+++ b/src/fetch_abis.ts
@@ -4,7 +4,7 @@
 const fetch_abis = async directory => {
   const fetch = require('node-fetch');
   const fs = require('fs');
-  const contracts = ['m.federation', 'atomicassets'];
+  const contracts = ['m.federation', 'atomicassets', 'notify.world'];
 
   for (let c = 0; c < contracts.length; c++) {
     const contract = contracts[c];


### PR DESCRIPTION
The api seems to have broken after pushing a contract change earlier today.
I suspect it's because it doesn't have the ABI loaded.